### PR TITLE
Refactor the process of creating capabilities for a session

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>11</java.version>
-        <carina-utils.version>1.0.2.P2-SNAPSHOT</carina-utils.version>
+        <carina-utils.version>1.0.2.P3-SNAPSHOT</carina-utils.version>
         <carina-commons.version>1.0.1</carina-commons.version>
         <carina-proxy.version>1.0.1</carina-proxy.version>
         <zebrunner-testng-pluggable.version>1.9.3</zebrunner-testng-pluggable.version>

--- a/src/main/java/com/zebrunner/carina/webdriver/core/capability/AbstractCapabilities.java
+++ b/src/main/java/com/zebrunner/carina/webdriver/core/capability/AbstractCapabilities.java
@@ -38,8 +38,7 @@ import com.zebrunner.carina.utils.R;
 import com.zebrunner.carina.utils.commons.SpecialKeywords;
 import com.zebrunner.carina.utils.exception.InvalidConfigurationException;
 
-import io.appium.java_client.remote.options.SupportsLanguageOption;
-import io.appium.java_client.remote.options.SupportsLocaleOption;
+import io.appium.java_client.remote.MobileCapabilityType;
 
 public abstract class AbstractCapabilities<T extends MutableCapabilities> {
     // TODO: [VD] reorganize in the same way Firefox profiles args/options if any and review other browsers
@@ -49,7 +48,10 @@ public abstract class AbstractCapabilities<T extends MutableCapabilities> {
     private static final Pattern CAPABILITY_WITH_TYPE_PATTERN = Pattern.compile("^(?<name>.+)(?<type>\\[.+\\])$");
 
     /**
-     * Generate Capabilities according to configuration file
+     * Get capabilities from the configuration ({@link R#CONFIG}).
+     * Additional capabilities can also be added (depends on implementation).
+     *
+     * @return see {@link T}
      */
     public abstract T getCapability(String testName);
 
@@ -99,7 +101,7 @@ public abstract class AbstractCapabilities<T extends MutableCapabilities> {
 
             // TODO add support of any nesting
             if (names.isEmpty()) {
-                // should never happens
+                // should never happen
                 throw new RuntimeException("Something went wrong when try to create capabilities from configuration.");
             } else if (names.size() == 1) {
                 options.setCapability(names.get(0), entry.getValue());
@@ -210,31 +212,28 @@ public abstract class AbstractCapabilities<T extends MutableCapabilities> {
          * Locale to set for iOS (XCUITest driver only) and Android.
          * fr_CA format for iOS. CA format (country name abbreviation) for Android
          */
-
         // parse locale param as it has language and country by default like en_US
         String localeValue = Configuration.get(Parameter.LOCALE);
         LOGGER.debug("Default locale value is : {}", localeValue);
         String[] values = localeValue.split("_");
         if (values.length == 1) {
             // only locale is present!
-            caps.setCapability(SupportsLocaleOption.LOCALE_OPTION, localeValue);
-
+            caps.setCapability(MobileCapabilityType.LOCALE, localeValue);
             String langValue = Configuration.get(Parameter.LANGUAGE);
             if (!langValue.isEmpty()) {
                 LOGGER.debug("Default language value is : {}", langValue);
                 // provide extra capability language only if it exists among config parameters...
-                caps.setCapability(SupportsLanguageOption.LANGUAGE_OPTION, langValue);
+                caps.setCapability(MobileCapabilityType.LANGUAGE, langValue);
             }
-
         } else if (values.length == 2) {
-            if (Configuration.getPlatform(caps).equalsIgnoreCase(SpecialKeywords.ANDROID)) {
+            if (Configuration.getPlatform().equalsIgnoreCase(SpecialKeywords.ANDROID)) {
                 LOGGER.debug("Put language and locale to android capabilities. language: {}; locale: {}", values[0], values[1]);
-                caps.setCapability(SupportsLanguageOption.LANGUAGE_OPTION, values[0]);
-                caps.setCapability(SupportsLocaleOption.LOCALE_OPTION, values[1]);
+                caps.setCapability(MobileCapabilityType.LANGUAGE, values[0]);
+                caps.setCapability(MobileCapabilityType.LOCALE, values[1]);
             } else if (Configuration.getPlatform().equalsIgnoreCase(SpecialKeywords.IOS)) {
                 LOGGER.debug("Put language and locale to iOS capabilities. language: {}; locale: {}", values[0], localeValue);
-                caps.setCapability(SupportsLanguageOption.LANGUAGE_OPTION, values[0]);
-                caps.setCapability(SupportsLocaleOption.LOCALE_OPTION, localeValue);
+                caps.setCapability(MobileCapabilityType.LANGUAGE, values[0]);
+                caps.setCapability(MobileCapabilityType.LOCALE, localeValue);
             }
         } else {
             LOGGER.error("Undefined locale provided (ignoring for mobile capabilitites): {}", localeValue);

--- a/src/main/java/com/zebrunner/carina/webdriver/core/capability/AbstractCapabilities.java
+++ b/src/main/java/com/zebrunner/carina/webdriver/core/capability/AbstractCapabilities.java
@@ -166,7 +166,7 @@ public abstract class AbstractCapabilities<T extends MutableCapabilities> {
                 }
             } else if ("[integer]".equalsIgnoreCase(type)) {
                 try {
-                    value = Integer.parseInt(type);
+                    value = Integer.parseInt(capabilityValue);
                 } catch (NumberFormatException e) {
                     throw new InvalidConfigurationException(
                             String.format("Provided integer type for '%s' capability, but it is not contains integer value.", name));

--- a/src/main/java/com/zebrunner/carina/webdriver/core/capability/AbstractCapabilities.java
+++ b/src/main/java/com/zebrunner/carina/webdriver/core/capability/AbstractCapabilities.java
@@ -33,7 +33,6 @@ import com.zebrunner.carina.utils.Configuration;
 import com.zebrunner.carina.utils.Configuration.Parameter;
 import com.zebrunner.carina.utils.R;
 import com.zebrunner.carina.utils.commons.SpecialKeywords;
-import com.zebrunner.carina.webdriver.IDriverPool;
 
 import io.appium.java_client.remote.options.SupportsLanguageOption;
 import io.appium.java_client.remote.options.SupportsLocaleOption;
@@ -50,12 +49,13 @@ public abstract class AbstractCapabilities<T extends MutableCapabilities> {
 
     protected T initBaseCapabilities(T capabilities, String testName) {
 
-        if (!IDriverPool.DEFAULT.equalsIgnoreCase(testName)) {
-            // #1573: remove "default" driver name capability registration
-            // capabilities.setCapability("name", testName);
-            // todo investigate is in work, if not, think about another path
-            R.CONFIG.put(SpecialKeywords.CAPABILITIES + ".name", testName, true);
-        }
+        // [AS] PR #34
+        //        if (!IDriverPool.DEFAULT.equalsIgnoreCase(testName)) {
+        //            // #1573: remove "default" driver name capability registration
+        //            // capabilities.setCapability("name", testName);
+        //            // todo investigate is in work, if not, think about another path
+        //            R.CONFIG.put(SpecialKeywords.CAPABILITIES + ".name", testName, true);
+        //        }
 
         ProxyUtils.getSeleniumProxy()
                 .ifPresent(proxy -> capabilities.setCapability(CapabilityType.PROXY, proxy));

--- a/src/main/java/com/zebrunner/carina/webdriver/core/capability/CapabilitiesLoader.java
+++ b/src/main/java/com/zebrunner/carina/webdriver/core/capability/CapabilitiesLoader.java
@@ -15,13 +15,6 @@
  *******************************************************************************/
 package com.zebrunner.carina.webdriver.core.capability;
 
-import com.zebrunner.carina.utils.R;
-import com.zebrunner.carina.utils.commons.SpecialKeywords;
-import org.openqa.selenium.Capabilities;
-import org.openqa.selenium.MutableCapabilities;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -32,6 +25,14 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
+
+import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.MutableCapabilities;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.zebrunner.carina.utils.R;
+import com.zebrunner.carina.utils.commons.SpecialKeywords;
 
 /**
  * Created by yauhenipatotski on 10/26/15.
@@ -57,8 +58,7 @@ public class CapabilitiesLoader {
      * {@code capabilities.<name>=<value> will be attached to each WebDriver capabilities
      * <name>=<value> will override appropriate configuration parameter by new <value>}
      *
-     * @param fileName
-     *            String path to the properties file with custom capabilities and properties
+     * @param fileName path to the properties file with custom capabilities and properties
      * @param currentTestOnly boolean
      */
     public void loadCapabilities(String fileName, boolean currentTestOnly) {
@@ -105,33 +105,11 @@ public class CapabilitiesLoader {
      * @throws RuntimeException     if an error occurred while loading capabilities from a file
      */
     public MutableCapabilities getCapabilities(String fileName) {
-        MutableCapabilities capabilities = new MutableCapabilities();
-
-        LOGGER.info("Generating capabilities from {}", fileName);
+        MutableCapabilities options = new MutableCapabilities();
+        LOGGER.info("Generating capabilities from '{}'", fileName);
         Properties props = loadProperties(fileName);
-        final String prefix = SpecialKeywords.CAPABILITIES + ".";
-
-        @SuppressWarnings({ "rawtypes", "unchecked" })
-        Map<String, String> capabilitiesMap = new HashMap(props);
-        for (Map.Entry<String, String> entry : capabilitiesMap.entrySet()) {
-            if (entry.getKey().toLowerCase().startsWith(prefix)) {
-                String value = entry.getValue();
-                if (!value.isEmpty()) {
-                    String cap = entry.getKey().replaceAll(prefix, "");
-                    if ("false".equalsIgnoreCase(value)) {
-                        LOGGER.debug("Set capabilities value as boolean: false");
-                        capabilities.setCapability(cap, false);
-                    } else if ("true".equalsIgnoreCase(value)) {
-                        LOGGER.debug("Set capabilities value as boolean: true");
-                        capabilities.setCapability(cap, true);
-                    } else {
-                        LOGGER.debug("Set capabilities value as string: {}", value);
-                        capabilities.setCapability(cap, value);
-                    }
-                }
-            }
-        }
-        return capabilities;
+        AbstractCapabilities.addPropertiesCapabilities(options, props);
+        return options;
     }
 
     private Properties loadProperties(String fileName) {

--- a/src/main/java/com/zebrunner/carina/webdriver/core/capability/impl/desktop/ChromeCapabilities.java
+++ b/src/main/java/com/zebrunner/carina/webdriver/core/capability/impl/desktop/ChromeCapabilities.java
@@ -39,7 +39,8 @@ public class ChromeCapabilities extends AbstractCapabilities<ChromeOptions> {
     @Override
     public ChromeOptions getCapability(String testName) {
         ChromeOptions options = new ChromeOptions();
-        initBaseCapabilities(options, testName);
+        addProxy(options);
+        addConfigurationCapabilities(options);
         addChromeOptions(options);
         options.addArguments("--start-maximized", "--ignore-ssl-errors");
         options.setAcceptInsecureCerts(true);
@@ -145,6 +146,10 @@ public class ChromeCapabilities extends AbstractCapabilities<ChromeOptions> {
         if (Configuration.getBoolean(Configuration.Parameter.HEADLESS)
                 && driverType.equals(SpecialKeywords.DESKTOP)) {
             options.setHeadless(Configuration.getBoolean(Configuration.Parameter.HEADLESS));
+            // todo refactor with w3c rules or remove
+            LOGGER.info("Browser will be started in headless mode. VNC and Video will be disabled.");
+            options.setCapability("enableVNC", false);
+            options.setCapability("enableVideo", false);
         }
     }
 }

--- a/src/main/java/com/zebrunner/carina/webdriver/core/capability/impl/desktop/ChromeCapabilities.java
+++ b/src/main/java/com/zebrunner/carina/webdriver/core/capability/impl/desktop/ChromeCapabilities.java
@@ -30,6 +30,7 @@ import com.zebrunner.carina.utils.report.ReportContext;
 import com.zebrunner.carina.webdriver.core.capability.AbstractCapabilities;
 
 public class ChromeCapabilities extends AbstractCapabilities<ChromeOptions> {
+
     private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     /**

--- a/src/main/java/com/zebrunner/carina/webdriver/core/capability/impl/desktop/EdgeCapabilities.java
+++ b/src/main/java/com/zebrunner/carina/webdriver/core/capability/impl/desktop/EdgeCapabilities.java
@@ -37,7 +37,8 @@ public class EdgeCapabilities extends AbstractCapabilities<ChromiumOptions<?>> {
     @Override
     public ChromiumOptions<?> getCapability(String testName) {
         ChromiumOptions<?> capabilities = new ChromiumOptions<>(CapabilityType.BROWSER_NAME, Browser.EDGE.browserName(), "ms:edgeOptions");
-        initBaseCapabilities(capabilities, testName);
+        addProxy(capabilities);
+        addConfigurationCapabilities(capabilities);
         addEdgeOptions(capabilities);
         capabilities.addArguments("--start-maximized", "--ignore-ssl-errors");
         capabilities.setAcceptInsecureCerts(true);
@@ -76,6 +77,10 @@ public class EdgeCapabilities extends AbstractCapabilities<ChromiumOptions<?>> {
         if (Configuration.getBoolean(Configuration.Parameter.HEADLESS)
                 && driverType.equals(SpecialKeywords.DESKTOP)) {
             caps.setHeadless(Configuration.getBoolean(Configuration.Parameter.HEADLESS));
+            // todo refactor with w3c rules or remove
+            LOGGER.info("Browser will be started in headless mode. VNC and Video will be disabled.");
+            caps.setCapability("enableVNC", false);
+            caps.setCapability("enableVideo", false);
         }
     }
 }

--- a/src/main/java/com/zebrunner/carina/webdriver/core/capability/impl/desktop/EdgeCapabilities.java
+++ b/src/main/java/com/zebrunner/carina/webdriver/core/capability/impl/desktop/EdgeCapabilities.java
@@ -32,17 +32,18 @@ import com.zebrunner.carina.utils.report.ReportContext;
 import com.zebrunner.carina.webdriver.core.capability.AbstractCapabilities;
 
 public class EdgeCapabilities extends AbstractCapabilities<ChromiumOptions<?>> {
+
     private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     @Override
     public ChromiumOptions<?> getCapability(String testName) {
-        ChromiumOptions<?> capabilities = new ChromiumOptions<>(CapabilityType.BROWSER_NAME, Browser.EDGE.browserName(), "ms:edgeOptions");
-        addProxy(capabilities);
-        addConfigurationCapabilities(capabilities);
-        addEdgeOptions(capabilities);
-        capabilities.addArguments("--start-maximized", "--ignore-ssl-errors");
-        capabilities.setAcceptInsecureCerts(true);
-        return capabilities;
+        ChromiumOptions<?> options = new ChromiumOptions<>(CapabilityType.BROWSER_NAME, Browser.EDGE.browserName(), "ms:edgeOptions");
+        addProxy(options);
+        addConfigurationCapabilities(options);
+        addEdgeOptions(options);
+        options.addArguments("--start-maximized", "--ignore-ssl-errors");
+        options.setAcceptInsecureCerts(true);
+        return options;
     }
 
     private void addEdgeOptions(ChromiumOptions<?> caps) {

--- a/src/main/java/com/zebrunner/carina/webdriver/core/capability/impl/desktop/FirefoxCapabilities.java
+++ b/src/main/java/com/zebrunner/carina/webdriver/core/capability/impl/desktop/FirefoxCapabilities.java
@@ -42,7 +42,8 @@ public class FirefoxCapabilities extends AbstractCapabilities<FirefoxOptions> {
     @Override
     public FirefoxOptions getCapability(String testName) {
         FirefoxOptions capabilities = new FirefoxOptions();
-        initBaseCapabilities(capabilities, testName);
+        addProxy(capabilities);
+        addConfigurationCapabilities(capabilities);
         addFirefoxOptions(capabilities);
         FirefoxProfile profile = new FirefoxProfile();
         profile.setPreference("media.eme.enabled", true);
@@ -61,7 +62,8 @@ public class FirefoxCapabilities extends AbstractCapabilities<FirefoxOptions> {
      */
     public FirefoxOptions getCapability(String testName, FirefoxProfile profile) {
         FirefoxOptions capabilities = new FirefoxOptions();
-        initBaseCapabilities(capabilities, testName);
+        addProxy(capabilities);
+        addConfigurationCapabilities(capabilities);
         addFirefoxOptions(capabilities);
         capabilities.setProfile(profile);
         return capabilities;
@@ -99,6 +101,10 @@ public class FirefoxCapabilities extends AbstractCapabilities<FirefoxOptions> {
         if (Configuration.getBoolean(Configuration.Parameter.HEADLESS)
                 && driverType.equals(SpecialKeywords.DESKTOP)) {
             options.setHeadless(Configuration.getBoolean(Configuration.Parameter.HEADLESS));
+            // todo refactor with w3c rules or remove
+            LOGGER.info("Browser will be started in headless mode. VNC and Video will be disabled.");
+            options.setCapability("enableVNC", false);
+            options.setCapability("enableVideo", false);
         }
 
     }

--- a/src/main/java/com/zebrunner/carina/webdriver/core/capability/impl/desktop/FirefoxCapabilities.java
+++ b/src/main/java/com/zebrunner/carina/webdriver/core/capability/impl/desktop/FirefoxCapabilities.java
@@ -41,16 +41,15 @@ public class FirefoxCapabilities extends AbstractCapabilities<FirefoxOptions> {
      */
     @Override
     public FirefoxOptions getCapability(String testName) {
-        FirefoxOptions capabilities = new FirefoxOptions();
-        addProxy(capabilities);
-        addConfigurationCapabilities(capabilities);
-        addFirefoxOptions(capabilities);
+        FirefoxOptions options = new FirefoxOptions();
+        addProxy(options);
+        addConfigurationCapabilities(options);
+        addFirefoxOptions(options);
         FirefoxProfile profile = new FirefoxProfile();
         profile.setPreference("media.eme.enabled", true);
         profile.setPreference("media.gmp-manager.updateEnabled", true);
-
-        capabilities.setProfile(profile);
-        return capabilities;
+        options.setProfile(profile);
+        return options;
     }
 
     /**
@@ -61,12 +60,12 @@ public class FirefoxCapabilities extends AbstractCapabilities<FirefoxOptions> {
      * @return FirefoxOptions
      */
     public FirefoxOptions getCapability(String testName, FirefoxProfile profile) {
-        FirefoxOptions capabilities = new FirefoxOptions();
-        addProxy(capabilities);
-        addConfigurationCapabilities(capabilities);
-        addFirefoxOptions(capabilities);
-        capabilities.setProfile(profile);
-        return capabilities;
+        FirefoxOptions options = new FirefoxOptions();
+        addProxy(options);
+        addConfigurationCapabilities(options);
+        addFirefoxOptions(options);
+        options.setProfile(profile);
+        return options;
     }
 
     private void addFirefoxOptions(FirefoxOptions options) {

--- a/src/main/java/com/zebrunner/carina/webdriver/core/capability/impl/desktop/OperaCapabilities.java
+++ b/src/main/java/com/zebrunner/carina/webdriver/core/capability/impl/desktop/OperaCapabilities.java
@@ -26,7 +26,7 @@ public class OperaCapabilities extends AbstractCapabilities<MutableCapabilities>
     @Override
     public MutableCapabilities getCapability(String testName) {
         MutableCapabilities capabilities = new MutableCapabilities();
-        initBaseCapabilities(capabilities, testName);
+        addConfigurationCapabilities(capabilities);
         capabilities.setCapability(CapabilityType.BROWSER_NAME, Browser.OPERA.browserName());
 
         //TODO: add support for AUTO_DOWNLOAD and PROXY

--- a/src/main/java/com/zebrunner/carina/webdriver/core/capability/impl/desktop/SafariCapabilities.java
+++ b/src/main/java/com/zebrunner/carina/webdriver/core/capability/impl/desktop/SafariCapabilities.java
@@ -34,7 +34,8 @@ public class SafariCapabilities extends AbstractCapabilities<SafariOptions> {
         // it is strange that safari options is not contains browser
         safariOptions.setCapability(SupportsBrowserNameOption.BROWSER_NAME_OPTION, Browser.SAFARI.browserName());
         safariOptions.setCapability(CapabilityType.BROWSER_NAME, Browser.SAFARI.browserName());
-        initBaseCapabilities(safariOptions, testName);
+        addProxy(safariOptions);
+        addConfigurationCapabilities(safariOptions);
         return safariOptions;
     }
 }

--- a/src/main/java/com/zebrunner/carina/webdriver/core/capability/impl/desktop/SafariCapabilities.java
+++ b/src/main/java/com/zebrunner/carina/webdriver/core/capability/impl/desktop/SafariCapabilities.java
@@ -15,27 +15,16 @@
  *******************************************************************************/
 package com.zebrunner.carina.webdriver.core.capability.impl.desktop;
 
-import org.openqa.selenium.Platform;
-import org.openqa.selenium.remote.Browser;
-import org.openqa.selenium.remote.CapabilityType;
-
 import com.zebrunner.carina.webdriver.core.capability.AbstractCapabilities;
 
-import io.appium.java_client.remote.options.SupportsBrowserNameOption;
 import io.appium.java_client.safari.options.SafariOptions;
 
 public class SafariCapabilities extends AbstractCapabilities<SafariOptions> {
 
     @Override
     public SafariOptions getCapability(String testName) {
-        SafariOptions safariOptions = new SafariOptions();
-        // we want to test safari not only on IOS, but on MAC
-        safariOptions.setPlatformName(Platform.ANY.toString());
-        // it is strange that safari options is not contains browser
-        safariOptions.setCapability(SupportsBrowserNameOption.BROWSER_NAME_OPTION, Browser.SAFARI.browserName());
-        safariOptions.setCapability(CapabilityType.BROWSER_NAME, Browser.SAFARI.browserName());
-        addProxy(safariOptions);
-        addConfigurationCapabilities(safariOptions);
-        return safariOptions;
+        SafariOptions options = new SafariOptions();
+        addConfigurationCapabilities(options);
+        return options;
     }
 }

--- a/src/main/java/com/zebrunner/carina/webdriver/core/capability/impl/mac/Mac2Capabilities.java
+++ b/src/main/java/com/zebrunner/carina/webdriver/core/capability/impl/mac/Mac2Capabilities.java
@@ -24,7 +24,7 @@ public class Mac2Capabilities extends AbstractCapabilities<Mac2Options> {
     @Override
     public Mac2Options getCapability(String testName) {
         Mac2Options capabilities = new Mac2Options();
-        initCapabilities(capabilities);
+        addConfigurationCapabilities(capabilities);
         return capabilities;
     }
 }

--- a/src/main/java/com/zebrunner/carina/webdriver/core/capability/impl/mac/Mac2Capabilities.java
+++ b/src/main/java/com/zebrunner/carina/webdriver/core/capability/impl/mac/Mac2Capabilities.java
@@ -23,8 +23,8 @@ public class Mac2Capabilities extends AbstractCapabilities<Mac2Options> {
 
     @Override
     public Mac2Options getCapability(String testName) {
-        Mac2Options capabilities = new Mac2Options();
-        addConfigurationCapabilities(capabilities);
-        return capabilities;
+        Mac2Options options = new Mac2Options();
+        addConfigurationCapabilities(options);
+        return options;
     }
 }

--- a/src/main/java/com/zebrunner/carina/webdriver/core/capability/impl/mobile/EspressoCapabilities.java
+++ b/src/main/java/com/zebrunner/carina/webdriver/core/capability/impl/mobile/EspressoCapabilities.java
@@ -27,7 +27,7 @@ public class EspressoCapabilities extends AbstractCapabilities<EspressoOptions> 
         // this step should be executed before initCapabilities() to be able to override this capabilities by default appium approach.
         setLocaleAndLanguage(capabilities);
         // add capabilities based on dynamic _config.properties variables
-        initCapabilities(capabilities);
+        addConfigurationCapabilities(capabilities);
         return capabilities;
     }
 }

--- a/src/main/java/com/zebrunner/carina/webdriver/core/capability/impl/mobile/EspressoCapabilities.java
+++ b/src/main/java/com/zebrunner/carina/webdriver/core/capability/impl/mobile/EspressoCapabilities.java
@@ -23,11 +23,10 @@ public class EspressoCapabilities extends AbstractCapabilities<EspressoOptions> 
 
     @Override
     public EspressoOptions getCapability(String testName) {
-        EspressoOptions capabilities = new EspressoOptions();
+        EspressoOptions options = new EspressoOptions();
         // this step should be executed before initCapabilities() to be able to override this capabilities by default appium approach.
-        setLocaleAndLanguage(capabilities);
-        // add capabilities based on dynamic _config.properties variables
-        addConfigurationCapabilities(capabilities);
-        return capabilities;
+        setLocaleAndLanguage(options);
+        addConfigurationCapabilities(options);
+        return options;
     }
 }

--- a/src/main/java/com/zebrunner/carina/webdriver/core/capability/impl/mobile/UiAutomator2Capabilities.java
+++ b/src/main/java/com/zebrunner/carina/webdriver/core/capability/impl/mobile/UiAutomator2Capabilities.java
@@ -27,7 +27,7 @@ public class UiAutomator2Capabilities extends AbstractCapabilities<UiAutomator2O
         // this step should be executed before initCapabilities() to be able to override this capabilities by default appium approach.
         setLocaleAndLanguage(capabilities);
         // add capabilities based on dynamic _config.properties variables
-        initCapabilities(capabilities);
+        addConfigurationCapabilities(capabilities);
         return capabilities;
     }
 }

--- a/src/main/java/com/zebrunner/carina/webdriver/core/capability/impl/mobile/UiAutomator2Capabilities.java
+++ b/src/main/java/com/zebrunner/carina/webdriver/core/capability/impl/mobile/UiAutomator2Capabilities.java
@@ -23,11 +23,10 @@ public class UiAutomator2Capabilities extends AbstractCapabilities<UiAutomator2O
 
     @Override
     public UiAutomator2Options getCapability(String testName) {
-        UiAutomator2Options capabilities = new UiAutomator2Options();
+        UiAutomator2Options options = new UiAutomator2Options();
         // this step should be executed before initCapabilities() to be able to override this capabilities by default appium approach.
-        setLocaleAndLanguage(capabilities);
-        // add capabilities based on dynamic _config.properties variables
-        addConfigurationCapabilities(capabilities);
-        return capabilities;
+        setLocaleAndLanguage(options);
+        addConfigurationCapabilities(options);
+        return options;
     }
 }

--- a/src/main/java/com/zebrunner/carina/webdriver/core/capability/impl/mobile/XCUITestCapabilities.java
+++ b/src/main/java/com/zebrunner/carina/webdriver/core/capability/impl/mobile/XCUITestCapabilities.java
@@ -27,7 +27,7 @@ public class XCUITestCapabilities extends AbstractCapabilities<XCUITestOptions> 
         // this step should be executed before initCapabilities() to be able to override this capabilities by default appium approach.
         setLocaleAndLanguage(capabilities);
         // add capabilities based on dynamic _config.properties variables
-        initCapabilities(capabilities);
+        addConfigurationCapabilities(capabilities);
         return capabilities;
     }
 }

--- a/src/main/java/com/zebrunner/carina/webdriver/core/capability/impl/mobile/XCUITestCapabilities.java
+++ b/src/main/java/com/zebrunner/carina/webdriver/core/capability/impl/mobile/XCUITestCapabilities.java
@@ -23,11 +23,10 @@ public class XCUITestCapabilities extends AbstractCapabilities<XCUITestOptions> 
 
     @Override
     public XCUITestOptions getCapability(String testName) {
-        XCUITestOptions capabilities = new XCUITestOptions();
+        XCUITestOptions options = new XCUITestOptions();
         // this step should be executed before initCapabilities() to be able to override this capabilities by default appium approach.
-        setLocaleAndLanguage(capabilities);
-        // add capabilities based on dynamic _config.properties variables
-        addConfigurationCapabilities(capabilities);
-        return capabilities;
+        setLocaleAndLanguage(options);
+        addConfigurationCapabilities(options);
+        return options;
     }
 }

--- a/src/main/java/com/zebrunner/carina/webdriver/core/capability/impl/windows/WindowsCapabilities.java
+++ b/src/main/java/com/zebrunner/carina/webdriver/core/capability/impl/windows/WindowsCapabilities.java
@@ -24,7 +24,7 @@ public class WindowsCapabilities extends AbstractCapabilities<WindowsOptions> {
     @Override
     public WindowsOptions getCapability(String testName) {
         WindowsOptions capabilities = new WindowsOptions();
-        initCapabilities(capabilities);
+        addConfigurationCapabilities(capabilities);
         return capabilities;
     }    
 }

--- a/src/main/java/com/zebrunner/carina/webdriver/core/capability/impl/windows/WindowsCapabilities.java
+++ b/src/main/java/com/zebrunner/carina/webdriver/core/capability/impl/windows/WindowsCapabilities.java
@@ -23,8 +23,8 @@ public class WindowsCapabilities extends AbstractCapabilities<WindowsOptions> {
 
     @Override
     public WindowsOptions getCapability(String testName) {
-        WindowsOptions capabilities = new WindowsOptions();
-        addConfigurationCapabilities(capabilities);
-        return capabilities;
+        WindowsOptions options = new WindowsOptions();
+        addConfigurationCapabilities(options);
+        return options;
     }    
 }

--- a/src/main/java/com/zebrunner/carina/webdriver/core/factory/impl/MacFactory.java
+++ b/src/main/java/com/zebrunner/carina/webdriver/core/factory/impl/MacFactory.java
@@ -15,24 +15,25 @@
  *******************************************************************************/
 package com.zebrunner.carina.webdriver.core.factory.impl;
 
-import com.zebrunner.carina.utils.Configuration;
-import com.zebrunner.carina.utils.commons.SpecialKeywords;
-import com.zebrunner.carina.webdriver.core.capability.impl.mac.Mac2Capabilities;
-import com.zebrunner.carina.webdriver.core.factory.AbstractFactory;
-import io.appium.java_client.mac.Mac2Driver;
+import java.io.UncheckedIOException;
+import java.lang.invoke.MethodHandles;
+import java.net.MalformedURLException;
+import java.net.URL;
+
 import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.WebDriver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.UncheckedIOException;
-import java.lang.invoke.MethodHandles;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.Objects;
+import com.zebrunner.carina.utils.Configuration;
+import com.zebrunner.carina.webdriver.core.capability.impl.mac.Mac2Capabilities;
+import com.zebrunner.carina.webdriver.core.factory.AbstractFactory;
+import com.zebrunner.carina.webdriver.listener.EventFiringAppiumCommandExecutor;
+
+import io.appium.java_client.mac.Mac2Driver;
 
 /**
- * WindowsFactory creates instance {@link WebDriver} for Windows native application testing.
+ * MacFactory creates instance {@link WebDriver} for Mac native application testing.
  * 
  * @author Sergei Zagriychuk (sergeizagriychuk@gmail.com)
  */
@@ -42,34 +43,22 @@ public class MacFactory extends AbstractFactory {
 
     @Override
     public WebDriver create(String name, MutableCapabilities capabilities, String seleniumHost) {
-
         if (seleniumHost == null) {
             seleniumHost = Configuration.getSeleniumUrl();
         }
-        LOGGER.debug("selenium: {}", seleniumHost);
-
-        String driverType = Configuration.getDriverType(capabilities);
-        if (!SpecialKeywords.MAC.equals(driverType)) {
-            throw new RuntimeException(String.format("Driver type %s is not applicable for Windows driver", driverType));
-        }
+        LOGGER.debug("Selenium URL: {}", seleniumHost);
 
         if (isCapabilitiesEmpty(capabilities)) {
             capabilities = new Mac2Capabilities().getCapability(name);
-            ;
         }
 
-        if (Objects.equals(Configuration.get(Configuration.Parameter.W3C), "false")) {
-            capabilities = removeAppiumPrefix(capabilities);
-        }
+        LOGGER.debug("Capabilities: {}", capabilities);
 
-        LOGGER.debug("capabilities: {}", capabilities);
-
-        URL url;
         try {
-            url = new URL(seleniumHost);
+            EventFiringAppiumCommandExecutor ce = new EventFiringAppiumCommandExecutor(new URL(seleniumHost));
+            return new Mac2Driver(ce, capabilities);
         } catch (MalformedURLException e) {
             throw new UncheckedIOException("Malformed appium URL!", e);
         }
-        return new Mac2Driver(url, capabilities);
     }
 }

--- a/src/main/java/com/zebrunner/carina/webdriver/core/factory/impl/MobileFactory.java
+++ b/src/main/java/com/zebrunner/carina/webdriver/core/factory/impl/MobileFactory.java
@@ -15,18 +15,21 @@
  *******************************************************************************/
 package com.zebrunner.carina.webdriver.core.factory.impl;
 
+import java.io.UncheckedIOException;
 import java.lang.invoke.MethodHandles;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang3.StringUtils;
 import org.openqa.selenium.HasCapabilities;
 import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.remote.Browser;
+import org.openqa.selenium.remote.CapabilityType;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,8 +40,10 @@ import com.zebrunner.carina.utils.Configuration;
 import com.zebrunner.carina.utils.Configuration.Parameter;
 import com.zebrunner.carina.utils.R;
 import com.zebrunner.carina.utils.commons.SpecialKeywords;
+import com.zebrunner.carina.utils.exception.InvalidConfigurationException;
 import com.zebrunner.carina.utils.mobile.ArtifactProvider;
 import com.zebrunner.carina.webdriver.IDriverPool;
+import com.zebrunner.carina.webdriver.core.capability.AbstractCapabilities;
 import com.zebrunner.carina.webdriver.core.capability.impl.mobile.EspressoCapabilities;
 import com.zebrunner.carina.webdriver.core.capability.impl.mobile.UiAutomator2Capabilities;
 import com.zebrunner.carina.webdriver.core.capability.impl.mobile.XCUITestCapabilities;
@@ -47,10 +52,11 @@ import com.zebrunner.carina.webdriver.device.Device;
 import com.zebrunner.carina.webdriver.listener.EventFiringAppiumCommandExecutor;
 
 import io.appium.java_client.android.AndroidDriver;
+import io.appium.java_client.internal.CapabilityHelpers;
 import io.appium.java_client.ios.IOSDriver;
 import io.appium.java_client.remote.AutomationName;
 import io.appium.java_client.remote.MobileCapabilityType;
-import io.appium.java_client.remote.options.SupportsAutomationNameOption;
+import io.appium.java_client.safari.SafariDriver;
 
 /**
  * MobileFactory creates instance {@link WebDriver} for mobile testing.
@@ -85,11 +91,10 @@ public class MobileFactory extends AbstractFactory {
 
     @Override
     public WebDriver create(String name, MutableCapabilities capabilities, String seleniumHost) {
-
         if (seleniumHost == null) {
             seleniumHost = Configuration.getSeleniumUrl();
         }
-
+        LOGGER.debug("Selenium URL: {}", seleniumHost);
         String mobilePlatformName = Configuration.getPlatform();
 
         // TODO: refactor to be able to remove SpecialKeywords.CUSTOM property completely
@@ -120,10 +125,6 @@ public class MobileFactory extends AbstractFactory {
             LOGGER.debug("Appended udid to capabilities: {}", capabilities);
         }
 
-        if (Objects.equals(Configuration.get(Parameter.W3C), "false")) {
-            capabilities = removeAppiumPrefix(capabilities);
-        }
-
         if (capabilities.getBrowserName() != null &&
                 (mobilePlatformName.equalsIgnoreCase(SpecialKeywords.ANDROID) ||
                         mobilePlatformName.equalsIgnoreCase(SpecialKeywords.IOS)) &&
@@ -141,24 +142,28 @@ public class MobileFactory extends AbstractFactory {
         LOGGER.debug("capabilities: {}", capabilities);
 
         try {
+            String browserName = CapabilityHelpers.getCapability(capabilities, CapabilityType.BROWSER_NAME, String.class);
             EventFiringAppiumCommandExecutor ce = new EventFiringAppiumCommandExecutor(new URL(seleniumHost));
 
-            if (mobilePlatformName.equalsIgnoreCase(SpecialKeywords.ANDROID)) {
+            if (SpecialKeywords.ANDROID.equalsIgnoreCase(mobilePlatformName)) {
                 driver = new AndroidDriver(ce, capabilities);
-
-            } else if (mobilePlatformName.equalsIgnoreCase(SpecialKeywords.IOS)
-                    || mobilePlatformName.equalsIgnoreCase(SpecialKeywords.TVOS)) {
-                driver = new IOSDriver(ce, capabilities);
-
+            } else if (SpecialKeywords.IOS.equalsIgnoreCase(mobilePlatformName) ||
+                    SpecialKeywords.TVOS.equalsIgnoreCase(mobilePlatformName)) {
+                if (Browser.SAFARI.browserName().equalsIgnoreCase(browserName)) {
+                    driver = new SafariDriver(ce, capabilities);
+                } else if (StringUtils.isBlank(browserName)) {
+                    driver = new IOSDriver(ce, capabilities);
+                } else {
+                    throw new InvalidConfigurationException("Unsupported browser for IOS: " + browserName);
+                }
             } else if (mobilePlatformName.equalsIgnoreCase(SpecialKeywords.CUSTOM)) {
                 // that's a case for custom mobile capabilities like browserstack or saucelabs
                 driver =new RemoteWebDriver(new URL(seleniumHost), capabilities);
-
             } else {
-                throw new RuntimeException("Unsupported mobile platform: " + mobilePlatformName);
+                throw new InvalidConfigurationException("Unsupported mobile platform: " + mobilePlatformName);
             }
         } catch (MalformedURLException e) {
-            throw new RuntimeException("Malformed selenium URL!", e);
+            throw new UncheckedIOException("Malformed selenium URL!", e);
         } catch (Exception e) {
             Device device = IDriverPool.nullDevice;
             LOGGER.debug("STF is enabled. Debug info will be extracted from the exception.");
@@ -222,21 +227,21 @@ public class MobileFactory extends AbstractFactory {
     }
 
     private MutableCapabilities getCapabilities(String name) {
-        String platform = Configuration.getPlatform();
-        String automationName = R.CONFIG.get("capabilities." + SupportsAutomationNameOption.AUTOMATION_NAME_OPTION);
+        String platform = R.CONFIG.get("capabilities." + CapabilityType.PLATFORM_NAME);
+        String automationName = R.CONFIG.get("capabilities." + MobileCapabilityType.AUTOMATION_NAME);
 
+        AbstractCapabilities<?> capabilities = null;
         if (AutomationName.ESPRESSO.equalsIgnoreCase(automationName)) {
-            return new EspressoCapabilities().getCapability(name);
-        }
-
-        if (platform.equalsIgnoreCase(SpecialKeywords.ANDROID)) {
-            return new UiAutomator2Capabilities().getCapability(name);
-
+            capabilities = new EspressoCapabilities();
+        } else if (SpecialKeywords.ANDROID.equalsIgnoreCase(platform)) {
+            capabilities = new UiAutomator2Capabilities();
         } else if (platform.equalsIgnoreCase(SpecialKeywords.IOS)
                 || platform.equalsIgnoreCase(SpecialKeywords.TVOS)) {
-            return new XCUITestCapabilities().getCapability(name);
+            capabilities = new XCUITestCapabilities();
+        } else {
+            throw new InvalidConfigurationException("Unsupported platform: " + platform);
         }
-        throw new RuntimeException("Unsupported platform: " + platform);
+        return capabilities.getCapability(name);
     }
 
     /**

--- a/src/main/java/com/zebrunner/carina/webdriver/core/factory/impl/WindowsFactory.java
+++ b/src/main/java/com/zebrunner/carina/webdriver/core/factory/impl/WindowsFactory.java
@@ -15,20 +15,22 @@
  *******************************************************************************/
 package com.zebrunner.carina.webdriver.core.factory.impl;
 
-import com.zebrunner.carina.utils.Configuration;
-import com.zebrunner.carina.webdriver.core.capability.impl.windows.WindowsCapabilities;
-import com.zebrunner.carina.webdriver.core.factory.AbstractFactory;
-import io.appium.java_client.windows.WindowsDriver;
+import java.io.UncheckedIOException;
+import java.lang.invoke.MethodHandles;
+import java.net.MalformedURLException;
+import java.net.URL;
+
 import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.WebDriver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.UncheckedIOException;
-import java.lang.invoke.MethodHandles;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.Objects;
+import com.zebrunner.carina.utils.Configuration;
+import com.zebrunner.carina.webdriver.core.capability.impl.windows.WindowsCapabilities;
+import com.zebrunner.carina.webdriver.core.factory.AbstractFactory;
+import com.zebrunner.carina.webdriver.listener.EventFiringAppiumCommandExecutor;
+
+import io.appium.java_client.windows.WindowsDriver;
 
 /**
  * WindowsFactory creates instance {@link WebDriver} for Windows native application testing.
@@ -44,24 +46,18 @@ public class WindowsFactory extends AbstractFactory {
         if (seleniumHost == null) {
             seleniumHost = Configuration.getSeleniumUrl();
         }
-        LOGGER.debug("selenium: {}", seleniumHost);
+        LOGGER.debug("Selenium URL: {}", seleniumHost);
 
         if (isCapabilitiesEmpty(capabilities)) {
             capabilities = new WindowsCapabilities().getCapability(name);
         }
+        LOGGER.debug("Capabilities: {}", capabilities);
 
-        if (Objects.equals(Configuration.get(Configuration.Parameter.W3C), "false")) {
-            capabilities = removeAppiumPrefix(capabilities);
-        }
-
-        LOGGER.debug("capabilities: {}", capabilities);
-
-        URL url;
         try {
-            url = new URL(seleniumHost);
+            EventFiringAppiumCommandExecutor ce = new EventFiringAppiumCommandExecutor(new URL(seleniumHost));
+            return new WindowsDriver(ce, capabilities);
         } catch (MalformedURLException e) {
             throw new UncheckedIOException("Malformed appium URL!", e);
         }
-        return new WindowsDriver(url, capabilities);
     }
 }

--- a/src/main/java/com/zebrunner/carina/webdriver/device/Device.java
+++ b/src/main/java/com/zebrunner/carina/webdriver/device/Device.java
@@ -48,6 +48,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 public class Device implements IDriverPool {
+    // TODO Review grid capabilities functionality (for example, slotCapabilities)
+
     private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private String name;
     private String type;

--- a/src/main/resources/config.properties
+++ b/src/main/resources/config.properties
@@ -51,5 +51,3 @@ retry_interval=100
 
 language=NULL
 provider=NULL
-w3c=false
-capabilities.providerOptions=options

--- a/src/test/java/com/zebrunner/carina/webdriver/core/capability/CapabilitiesLoaderTest.java
+++ b/src/test/java/com/zebrunner/carina/webdriver/core/capability/CapabilitiesLoaderTest.java
@@ -15,14 +15,20 @@
  *******************************************************************************/
 package com.zebrunner.carina.webdriver.core.capability;
 
+import java.io.UncheckedIOException;
+import java.util.HashMap;
+
 import org.openqa.selenium.MutableCapabilities;
+import org.openqa.selenium.Platform;
+import org.openqa.selenium.remote.Browser;
+import org.openqa.selenium.remote.CapabilityType;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import com.zebrunner.carina.utils.R;
 
-import java.io.FileNotFoundException;
-import java.io.UncheckedIOException;
+import io.appium.java_client.remote.AutomationName;
+import io.appium.java_client.remote.MobileCapabilityType;
 
 public class CapabilitiesLoaderTest {
 
@@ -49,6 +55,33 @@ public class CapabilitiesLoaderTest {
             UncheckedIOException.class }, expectedExceptionsMessageRegExp = "java.io.FileNotFoundException: Unable to find custom capabilities file 'unexisting_file'.")
     public void loadCapabilitiesFromNonExistingFileTest() {
         new CapabilitiesLoader().loadCapabilities("unexisting_file");
+    }
+
+    @Test
+    public void getW3CCapabilitiesTest() {
+        MutableCapabilities capabilities = new CapabilitiesLoader().getCapabilities(customCapabilities);
+        Assert.assertNull(capabilities.getCapability("coreParam"), "Capabilities should not contains parameter from configuration"
+                + "that has no 'capabilities.' prefix.");
+
+        Assert.assertEquals(capabilities.getCapability(CapabilityType.PLATFORM_NAME), Platform.ANDROID,
+                "Capabilities should contains android platform.");
+        Assert.assertEquals(capabilities.getCapability(CapabilityType.BROWSER_NAME), Browser.CHROME.browserName(),
+                "Capabilities should contains chrome browser name.");
+
+        Assert.assertEquals(capabilities.getCapability(MobileCapabilityType.AUTOMATION_NAME), AutomationName.ESPRESSO.toLowerCase(),
+                "Capabilities should contains espresso automation name without prefix.");
+        Assert.assertEquals(capabilities.getCapability("appium:" + MobileCapabilityType.PLATFORM_VERSION), 11,
+                "Capabilities should contains 11 platfrom version as integer.");
+
+        Assert.assertEquals(capabilities.getCapability("zebrunner:enableLog"), true);
+        Assert.assertEquals(capabilities.getCapability("zebrunner:name"), "Default");
+        Assert.assertEquals(capabilities.getCapability("zebrunner:idleTimeout"), "100");
+
+        Assert.assertNotNull(capabilities.getCapability("zebrunner:options"));
+        HashMap<String, Object> options = (HashMap<String, Object>) capabilities.getCapability("zebrunner:options");
+        Assert.assertEquals(options.get("idleTimeout"), "200");
+        Assert.assertEquals(options.get("waitForIdleTimeout"), 200);
+        Assert.assertEquals(options.get("enableVideo"), true);
     }
 
     /*

--- a/src/test/java/com/zebrunner/carina/webdriver/core/capability/impl/desktop/DesktopCapabilitiesTest.java
+++ b/src/test/java/com/zebrunner/carina/webdriver/core/capability/impl/desktop/DesktopCapabilitiesTest.java
@@ -50,7 +50,7 @@ public class DesktopCapabilitiesTest {
 
         Assert.assertEquals(capabilities.getBrowserName(), Browser.CHROME.browserName(), "Returned browser name is not valid!");
 
-        Assert.assertEquals(capabilities.getCapability("name"), testName, "Returned test name is not valid!");
+//        Assert.assertEquals(capabilities.getCapability("name"), testName, "Returned test name is not valid!");
         Map<String, Object> chromeOptions = (Map<String, Object>) capabilities.getCapability(ChromeOptions.CAPABILITY);
         List<String> chromeOptionsArgs = (List<String>) chromeOptions.get("args");
         Assert.assertTrue(chromeOptionsArgs.contains("--start-maximized"),
@@ -116,7 +116,7 @@ public class DesktopCapabilitiesTest {
 
         Assert.assertEquals(capabilities.getBrowserName(), Browser.OPERA.browserName(), "Returned browser name is not valid!");
 
-        Assert.assertEquals(capabilities.getCapability("name"), testName, "Returned test name is not valid!");
+//        Assert.assertEquals(capabilities.getCapability("name"), testName, "Returned test name is not valid!");
     }
 
    @Test(groups = {"DesktopCapabilitiesTestClass"}, enabled = false)
@@ -140,7 +140,7 @@ public class DesktopCapabilitiesTest {
 
         Assert.assertEquals(capabilities.getBrowserName(), Browser.EDGE.browserName(), "Returned browser name is not valid!");
 
-        Assert.assertEquals(capabilities.getCapability("name"), testName, "Returned test name is not valid!");
+//        Assert.assertEquals(capabilities.getCapability("name"), testName, "Returned test name is not valid!");
     }
 
     @Test(groups = {"DesktopCapabilitiesTestClass"})

--- a/src/test/java/com/zebrunner/carina/webdriver/tvos/AppleTVTest.java
+++ b/src/test/java/com/zebrunner/carina/webdriver/tvos/AppleTVTest.java
@@ -35,7 +35,7 @@ public class AppleTVTest {
 
 	@Test(groups = {"AppleTVTestClass"}, dependsOnGroups = {"DesktopCapabilitiesTestClass"})
 	public void getTvOSCapabilityTest() {
-		R.CONFIG.put(MOBILE_DEVICE_PLATFORM, TVOS);
+		R.CONFIG.put(MOBILE_DEVICE_PLATFORM, TVOS, true);
 		Assert.assertEquals(R.CONFIG.get(MOBILE_DEVICE_PLATFORM), TVOS);
 	}
 
@@ -55,13 +55,13 @@ public class AppleTVTest {
 
 	@Test(groups = {"AppleTVTestClass"}, dependsOnGroups = {"DesktopCapabilitiesTestClass"})
 	public void getTvOSPlatformTest() {
-		R.CONFIG.put(SpecialKeywords.PLATFORM_NAME, TVOS);
+		R.CONFIG.put(SpecialKeywords.PLATFORM_NAME, TVOS, true);
 		Assert.assertEquals(Configuration.getDriverType(), MOBILE);
 	}
 
 	@Test(groups = {"AppleTVTestClass"}, dependsOnGroups = {"DesktopCapabilitiesTestClass"})
 	public void negativeTvOSPlatformTest() {
-		R.CONFIG.put(SpecialKeywords.PLATFORM_NAME, TVOS);
+		R.CONFIG.put(SpecialKeywords.PLATFORM_NAME, TVOS, true);
 		Assert.assertNotEquals(Configuration.getDriverType(), DESKTOP);
 	}
 

--- a/src/test/resources/custom_capabilities.properties
+++ b/src/test/resources/custom_capabilities.properties
@@ -1,6 +1,34 @@
+# parameter that we should not see in result capabilities because it have no 'capabilities.' prefix
+coreParam=coreValue
+# for old tests
 capabilities.stringParam=stringValue
 capabilities.booleanParamTrue=true
 capabilities.booleanParamFalse=false
 
-coreParam=coreValue
+#w3c selenium standard capabilities
+capabilities.platformName=android
+capabilities.browserName=chrome
 
+# appium capabilities (we can set it with or without prefix)
+# without prefix
+capabilities.automationName=espresso
+# with prefix
+capabilities.appium\:platformVersion=11
+
+# specific capabilities without nesting
+# parse type boolean
+capabilities.zebrunner\:enableLog=true
+#parse type String
+capabilities.zebrunner\:name=Default
+# parse type String (explicitly)
+capabilities.zebrunner\:idleTimeout[String]=100
+
+# specific capabilities (with nesting)
+# parse type boolean
+capabilities.zebrunner\:options.enableLog=true
+# parse type String (explicitly)
+capabilities.zebrunner\:options.idleTimeout[String]=200
+# parse type Integer (explicitly)
+capabilities.zebrunner\:options.waitForIdleTimeout[integer]=200
+# parse type Boolean (explicitly)
+capabilities.zebrunner\:options.enableVideo[boolean]=true


### PR DESCRIPTION
Added the ability to explicitly specify the nesting of capabilities, for example you can use `capabilities.zebrunner\:options.enableVideo`,
Important: if the colon character is part of the capability name, then it should be like `\:`, since in properties this character  is the separator between the name and the value, just like the equals character.

Removed explicit casting of zebrunner capabilities such as idleTimeout (explicitly cast to String) and waitForIdleTimeout (explicitly cast to Integer). Now, if you need to explicitly specify the type (in non-standard cases), use the following format in the configuration, for example:
```properties
capabilities.zebrunner\:options.idleTimeout[string]=200
capabilities.zebrunner\:options.waitForIdleTimeout[integer]=10
```

All Selenium and Appium capabilities should be provided in configuration file as is (without any prefix).

- [x] **feature** add opportunity to use nested capabilities in configuration
- [x] **feature** add opportunity to add information about type of the capability in configuration
- [ ] **investigate** Device class -> how we should get deviceType capability
- [ ] **investigate** how we should get `slotCapabilities` in Device class
- [x] **refactor** Remove usage of w3c parameter
- [ ]  **refactor** remove `w3c` parameter, `capabilities.providerOptions` from `carina-utils`
- [x] **refactor** remove setting `name` capability in AbstractCapabilities. In w3c-style different Test platforms have different name for this capability. Also thing about removing `name` parameter from methods for generating Capabilities
- [ ] **refactor** remove setting `enableVideo=false` and `enableVNC=false` if `headless` parameter equals true. This logic should not be in Carina
- [ ] **feature** reorganize all capabilities/options/arguments in the same way as in firefox
- [ ] **investigate** how we should get "pixelRatio" capability in Screenshot class