### PR TITLE
Revert "Removed workaround for esg test download dir pref"

### DIFF
--- a/src/main/java/com/zebrunner/carina/webdriver/core/capability/impl/desktop/ChromeCapabilities.java
+++ b/src/main/java/com/zebrunner/carina/webdriver/core/capability/impl/desktop/ChromeCapabilities.java
@@ -72,7 +72,10 @@ public class ChromeCapabilities extends AbstractCapabilities<ChromeOptions> {
 
         if (Configuration.getBoolean(Configuration.Parameter.AUTO_DOWNLOAD)) {
             chromePrefs.put("download.prompt_for_download", false);
-            chromePrefs.put("download.default_directory", ReportContext.getArtifactsFolder().getAbsolutePath());
+            if (!"zebrunner".equalsIgnoreCase(getProvider())) {
+                // don't override auto download dir for Zebrunner Selenium Grid (Selenoid)
+                chromePrefs.put("download.default_directory", ReportContext.getArtifactsFolder().getAbsolutePath());
+            }
             chromePrefs.put("plugins.always_open_pdf_externally", true);
             needsPrefs = true;
         }

--- a/src/main/java/com/zebrunner/carina/webdriver/core/capability/impl/desktop/EdgeCapabilities.java
+++ b/src/main/java/com/zebrunner/carina/webdriver/core/capability/impl/desktop/EdgeCapabilities.java
@@ -60,8 +60,10 @@ public class EdgeCapabilities extends AbstractCapabilities<EdgeOptions> {
 
         if (Configuration.getBoolean(Configuration.Parameter.AUTO_DOWNLOAD)) {
             prefs.put("download.prompt_for_download", false);
-            prefs.put("download.default_directory",
-                    ReportContext.getArtifactsFolder().getAbsolutePath());
+            if (!"zebrunner".equalsIgnoreCase(getProvider())) {
+                prefs.put("download.default_directory",
+                        ReportContext.getArtifactsFolder().getAbsolutePath());
+            }
             needsPrefs = true;
         }
 

--- a/src/main/java/com/zebrunner/carina/webdriver/core/capability/impl/desktop/FirefoxCapabilities.java
+++ b/src/main/java/com/zebrunner/carina/webdriver/core/capability/impl/desktop/FirefoxCapabilities.java
@@ -148,7 +148,10 @@ public class FirefoxCapabilities extends AbstractCapabilities<FirefoxOptions> {
         if (Configuration.getBoolean(Configuration.Parameter.AUTO_DOWNLOAD) && !(Configuration.isNull(Configuration.Parameter.AUTO_DOWNLOAD_APPS)
                 || "".equals(Configuration.get(Configuration.Parameter.AUTO_DOWNLOAD_APPS)))) {
             profile.setPreference("browser.download.folderList", 2);
-            profile.setPreference("browser.download.dir", ReportContext.getArtifactsFolder().getAbsolutePath());
+            if (!"zebrunner".equalsIgnoreCase(getProvider())) {
+                // don't override auto download dir for Zebrunner Selenium Grid (Selenoid)
+                profile.setPreference("browser.download.dir", ReportContext.getArtifactsFolder().getAbsolutePath());
+            }
             profile.setPreference("browser.helperApps.neverAsk.saveToDisk", Configuration.get(Configuration.Parameter.AUTO_DOWNLOAD_APPS));
             profile.setPreference("browser.download.manager.showWhenStarting", false);
             profile.setPreference("browser.download.saveLinkAsFilenameTimeout", 1);


### PR DESCRIPTION
Reverts zebrunner/carina-webdriver#109